### PR TITLE
Make setup compatible with spaces in path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-os:
-  - linux
-  - osx
 python:
   - "3.6"
 # Only test on Python 3.6 initially

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os:
+  - linux
+  - osx
 python:
   - "3.6"
 # Only test on Python 3.6 initially

--- a/scripts/setupPGD.sh
+++ b/scripts/setupPGD.sh
@@ -9,17 +9,16 @@
 
 #Get repository directory and set up lib
 homeDir=`git rev-parse --show-toplevel`;
-mkdir ${homeDir}/lib;
-mkdir ${homeDir}/lib/pgd;
+mkdir -p "${homeDir}/lib/pgd";
 
 #Get PGD from github and compile it
 #git clone https://github.com/nkahmed/PGD.git ${homeDir}/lib/pgd/;
 #git --git-dir=${homeDir}/lib/pgd/.git checkout 05fef84db271554cc6ff2dbac9964c614e0c7981;
-git clone https://github.com/rbassett3/PGD.git ${homeDir}/lib/pgd/;
-git --git-dir=${homeDir}/lib/pgd/.git checkout cdccc5e92fc012de292364f8f9ded7e185dbe9cb;
-make -C ${homeDir}/lib/pgd/;
+git clone https://github.com/rbassett3/PGD.git "${homeDir}/lib/pgd/";
+git --git-dir="${homeDir}/lib/pgd/.git" checkout cdccc5e92fc012de292364f8f9ded7e185dbe9cb;
+make -C "${homeDir}/lib/pgd/";
 
 #Test run without saving any output
-python ${homeDir}/scripts/makePGDNet.py ${homeDir}/data/IL2/pathways/p5e-2.sif;
-${homeDir}/lib/pgd/pgd -f ${homeDir}/data/IL2/graphlets/p5e-2.sif;
-rm ${homeDir}/data/IL2/graphlets/p5e-2.sif;
+python "${homeDir}/scripts/makePGDNet.py" "${homeDir}/data/IL2/pathways/p5e-2.sif";
+"${homeDir}/lib/pgd/pgd" -f "${homeDir}/data/IL2/graphlets/p5e-2.sif";
+rm "${homeDir}/data/IL2/graphlets/p5e-2.sif";


### PR DESCRIPTION
The setup script currently fails if `homeDir` contains spaces in the path.