### PR TITLE
Improve macOS compatibility and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   # See https://docs.travis-ci.com/user/languages/c/#gcc-on-macos
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc@10
-      export CC=gcc-10
-      export CXX=g++-10
+      brew install gcc5
+      export CC=gcc-5
+      export CXX=g++-5
     fi
   - cd bin
   - bash setupPGD.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,37 @@
-language: python
-python:
-  - "3.6"
-# Only test on Python 3.6 initially
-#  - "3.7"
-#  - "3.8"
-cache:
-  - pip
+language: minimal
+
+os:
+  - linux
+  - osx
+
+# Multi-OS Miniconda install from https://github.com/gitter-lab/ssps/blob/master/.travis.yml
+before_install:
+  # Download OS-specific version of Miniconda installer
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh -O miniconda.sh
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source $HOME/miniconda/etc/profile.d/conda.sh
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  # Do not use a conda environment.yml file because there are few dependencies
+  - conda create -n ppa python=3.6 numpy=1.19 networkx=2.4 requests=2.24
+  - conda activate ppa
+
 install:
-  - pip install networkx numpy requests
-script:
+  # Install pathway parameter advising
   - python setup.py install
+  # Install PGD dependency
   - cd bin
-  # Installs pgd, uses graph conversion script, and runs PPA
   - bash setupPGD.sh
+
+script:
+  # Run PPA examples
   - bash runPPA.sh ../data/Wnt wnt_ranking.txt ../lib/pgd/ 
   - bash runNetBoxIL2.sh
   # Compare the generated IL2 output with the reference output

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   # See https://docs.travis-ci.com/user/languages/c/#gcc-on-macos
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc10
+      brew install gcc@10
       export CC=gcc-10
       export CXX=g++-10
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,9 @@ install:
   # See https://docs.travis-ci.com/user/languages/c/#gcc-on-macos
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc5
-      export CC=gcc-5
-      export CXX=g++-5
-      g++ --version
-      cmake --version
-      which g++
-      which g++-5
+      brew install gcc10
+      export CC=gcc-10
+      export CXX=g++-10
     fi
   - cd bin
   - bash setupPGD.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ install:
   # Install pathway parameter advising
   - python setup.py install
   # Install PGD dependency
+  # macOS has gcc as an alias for clang, so specifically set gcc
+  # See https://docs.travis-ci.com/user/languages/c/#gcc-on-macos
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew install gcc5
+      CC=gcc-5
+      CXX=g++-5
+    fi
   - cd bin
   - bash setupPGD.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,12 @@ install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install gcc5
-      CC=gcc-5
-      CXX=g++-5
+      export CC=gcc-5
+      export CXX=g++-5
+      g++ --version
+      cmake --version
+      which g++
+      which g++-5
     fi
   - cd bin
   - bash setupPGD.sh

--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ It takes the following positional arguments:
 ## Pathway reconstruction algorithms
 The pathway reconstruction algorithms used in the pathway parameter advising manuscript are available from:
 - PathLinker: [PathLinker](https://github.com/Murali-group/PathLinker)
-- NetBox: **add source**
+- NetBox: originally used [`netbox.tar.gz`](http://cbio.mskcc.org/wp-content/uploads/2012/10/netbox.tar.gz), which has since been replaced by [NetBoxR](https://www.bioconductor.org/packages/release/bioc/html/netboxr.html)
 - Prize-Collecting Steiner Forest: [OmicsIntegrator](https://github.com/fraenkel-lab/OmicsIntegrator/) and [msgsteiner](https://staff.polito.it/alfredo.braunstein/code/2010/08/19/msgsteiner.html)
 - Minimum-Cost Flow: [OR-Tools](https://developers.google.com/optimization/install) and **wrapper script**

--- a/README.md
+++ b/README.md
@@ -18,11 +18,25 @@ Pathway parameter advising was written and tested using Python 3.6 and requires 
 Graphlet decomposition is performed using the PGD library.
 The PGD library can be installed from its [GitHub repository](https://github.com/nkahmed/pgd) and complied using `make`.
 The script `setupPGD.sh` requires git, and has been provided to aid in installing the PGD library.
-However, it is not guaranteed to work and has only been tested on Ubuntu 18.04.
+However, it is not guaranteed to work on all systems and has only been tested on Ubuntu 18.04 and macOS 10.13.
 In general, these scripts have only been tested in a Linux environment initially.
 
+### Compiling PGD for macOS
+Many macOS systems use clang++ instead of g++ and set g++ as an alias for clang++.
+PGD requires g++ instead of clang++.
+Therefore, macOS users must install g++ and set it as the compiler before running the `setupPGD.sh` script.
+
+There are multiple options for installing g++.
+We recommend [Homebrew](https://brew.sh/).
+With Homebrew:
+
+1. Install gcc with the command `brew install gcc`
+2. Define the CC and CXX environmental variables according to the location of brew install. For example:
+- `export CC=/usr/local/Cellar/gcc/10.1.0/bin/gcc-10`
+- `export CXX=/usr/local/Cellar/gcc/10.1.0/bin/g++-10`
+
 ## Installation
-Pathway parameter advising can be download from either PyPI or Github.
+Pathway parameter advising can be download from either PyPI or GitHub.
 
 This package includes example data and scripts to manage reference pathways and aid in performing graphlet decomposition which are not a part of the binary Python package in PyPI.
 Therefore, it is recommended to download the package source.
@@ -67,6 +81,9 @@ The recommended way to use pathway parameter advising is through the script `bin
 >
 >  delim:         (Optional) The limiter used for edges in the input network files. Assumed to be whitespace.
 
+The `runPPA.sh` output is sorted from lowest to highest score.
+This is because the score is a distance from the reference pathways, so the parameter combination with the smallest score is best.
+See the [IL2 output](tests/reference/il2_ranking.txt) as an example.
 
 ### Running Python package directly
 
@@ -118,7 +135,7 @@ Files are the piped output from the pgd script: `./pgd -f inputGraphFile >> grap
 PGD is cloned from its [GitHub repository](https://github.com/nkahmed/pgd) and complied using `make`.
 It can then be run from the base pathway parameter advising directory as `lib/pgd/pgd -f inputGraphFile`.
 Note this script has been included to help install the PGD library, but is not guaranteed to run on all systems.
-It has been tested on Ubuntu 18.04.
+It has been tested on Ubuntu 18.04 and macOS 10.13.
 `setupPGD.sh` does not take any arguments.
 
 `bin/updateReactome.sh` downloads the latest version of all human Reactome pathways from [Pathway Commons](https://www.pathwaycommons.org/) and performs graphlet decomposition on them. 

--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ The pathway reconstruction algorithms used in the pathway parameter advising man
 - PathLinker: [PathLinker](https://github.com/Murali-group/PathLinker)
 - NetBox: originally used [`netbox.tar.gz`](http://cbio.mskcc.org/wp-content/uploads/2012/10/netbox.tar.gz), which has since been replaced by [NetBoxR](https://www.bioconductor.org/packages/release/bioc/html/netboxr.html)
 - Prize-Collecting Steiner Forest: [OmicsIntegrator](https://github.com/fraenkel-lab/OmicsIntegrator/) and [msgsteiner](https://staff.polito.it/alfredo.braunstein/code/2010/08/19/msgsteiner.html)
-- Minimum-Cost Flow: [OR-Tools](https://developers.google.com/optimization/install) and **wrapper script**
+- Minimum-Cost Flow: [OR-Tools](https://developers.google.com/optimization/install) and [wrapper script](https://github.com/gitter-lab/influenza-pb2)

--- a/README.md
+++ b/README.md
@@ -143,3 +143,10 @@ It takes the following positional arguments:
 >   pgdDirectory:      The directory where pgd is installed. Will default to '../lib/pgd'
 >
 >   reactomeDirectory: (Optional) The directory where Reactome pathways and graphlets will be stored. If not given will default to '../referencePathways'.
+
+## Pathway reconstruction algorithms
+The pathway reconstruction algorithms used in the pathway parameter advising manuscript are available from:
+- PathLinker: [PathLinker](https://github.com/Murali-group/PathLinker)
+- NetBox: **add source**
+- Prize-Collecting Steiner Forest: [OmicsIntegrator](https://github.com/fraenkel-lab/OmicsIntegrator/) and [msgsteiner](https://staff.polito.it/alfredo.braunstein/code/2010/08/19/msgsteiner.html)
+- Minimum-Cost Flow: [OR-Tools](https://developers.google.com/optimization/install) and **wrapper script**

--- a/bin/setupPGD.sh
+++ b/bin/setupPGD.sh
@@ -7,9 +7,10 @@
 # in the lib directory. The lib directory is made if none exists.
 #################################################
 
+set -o errexit
+
 #Get repository directory and set up lib
-mkdir ../lib;
-mkdir ../lib/pgd;
+mkdir -p ../lib/pgd;
 
 #Get PGD from github and compile it
 #git clone https://github.com/nkahmed/PGD.git ${homeDir}/lib/pgd/;

--- a/bin/setupPGD.sh
+++ b/bin/setupPGD.sh
@@ -17,6 +17,10 @@ mkdir -p ../lib/pgd;
 #git --git-dir=${homeDir}/lib/pgd/.git checkout 05fef84db271554cc6ff2dbac9964c614e0c7981;
 git clone https://github.com/rbassett3/PGD.git ../lib/pgd/;
 git --git-dir=../lib/pgd/.git checkout cdccc5e92fc012de292364f8f9ded7e185dbe9cb;
+
+# Remove the Makefile line that hard codes the compiler
+grep -vx 'CXX          = g++' ../lib/pgd/Makefile > tmp && mv -f tmp ../lib/pgd/Makefile
+
 make -C ../lib/pgd/;
 
 #Test run without saving any output

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
 
 
     #Package Topics
-    keywords = "pathway-finding parameter-advising pathway-reconstruction biological-pathway",
+    keywords = "pathway-finding parameter-advising pathway-reconstruction biological-pathway graphlet",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         "License :: OSI Approved :: MIT License",
         "Operating System :: Unix ",
+        'Operating System :: MacOS :: MacOS X'
     ],
     python_requires='>=3.6',
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Closes #12 

This pull request switches to conda for the Travis CI tests.  That allows us to test in a macOS environment and will also make it easier to later install a pathway reconstruction method to run an end-to-end example.

I modified the PGD setup script to remove the hard coded compiler.  That works for Linux and macOS, so it is one less macOS-specific step needed.  I also added @emmagraham's installation advice to the readme and implemented it in the macOS Travis CI test.  The test script installs g++ with brew and sets the environment variable.

These and other recent updates address almost all of Emma's recommendations.  The last one is to include an example of how the `nameMap` argument to `ppa.py` works.  We can add that to the readme before merging.